### PR TITLE
Condense travis "basic" tests stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,15 +36,13 @@ jobs:
   include:
     - stage: basic
       name: 'Conventional Commits'
-      script: commitlint-travis
-    - name: 'Lint'
+      install: yarn install --non-interactive
       script:
+        - commitlint-travis
         - lerna run lint:js
         - lerna run lint:ts
         - lerna run lint:hbs
-    - name: 'Fixed Dependencies'
-      install: yarn install --non-interactive
-      script: lerna run test:coverage
+        - lerna run test:coverage
       after_success: codecov
 
     - stage: compatibility

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-canary
   include:
     - stage: basic
-      name: 'Conventional Commits'
+      name: 'Conventional Commits, Lint and Fixed Dependencies'
       install: yarn install --non-interactive
       script:
         - commitlint-travis


### PR DESCRIPTION
There's no reason to break out commitlint, other linting and a test run
into seperate jobs